### PR TITLE
Separated C++ from C

### DIFF
--- a/autoload/TagHighlight/Generation.vim
+++ b/autoload/TagHighlight/Generation.vim
@@ -125,11 +125,11 @@ function! s:UpdateTypesFile()
 	if tag_file_info['Exists'] == 1
 		if TagHighlight#Option#GetOption('DoNotGenerateTagsIfPresent') == 1
 			" This will be unset in UpdateAndRead
-			call TagHLDebug("Tag file doesn't exist and DoNotGenerateTagsIfPresent set, not generating new tag file", "Information")
+			call TagHLDebug("Tag file exists and DoNotGenerateTagsIfPresent set, not generating new tag file", "Information")
 			let b:TagHighlightSettings['DoNotGenerateTags'] = 1
 		endif
 	elseif TagHighlight#Option#GetOption('DoNotGenerateTags') == 1
-		echoerr "Cannot create types file without generating tags: tags file does not exist"
+		echoerr "Cannot create types file without tags: tags file does not exist"
 		return
 	endif
 

--- a/plugin/TagHighlight/data/language_defaults.txt
+++ b/plugin/TagHighlight/data/language_defaults.txt
@@ -17,18 +17,18 @@
 Priority:
 	CTagsNamespace
 	CTagsClass
-	CTagsDefinedName
-	CTagsType
-	CTagsMethod
-	CTagsFunction
-	CTagsEnumerationValue
-	CTagsEnumeratorName
-	CTagsConstant
-	CTagsGlobalVariable
-	CTagsUnion
-	CTagsProperty
-	CTagsMember
 	CTagsStructure
+	CTagsEnumeratorName
+	CTagsUnion
+	CTagsType
+	CTagsEnumerationValue
+	CTagsDefinedName
+	CTagsConstant
+	CTagsMethod
+	CTagsMember
+	CTagsProperty
+	CTagsFunction
+	CTagsGlobalVariable
 SkipList:
 IsKeyword:@,48-57,_,192-255
 

--- a/plugin/TagHighlight/data/language_defaults.txt
+++ b/plugin/TagHighlight/data/language_defaults.txt
@@ -17,18 +17,18 @@
 Priority:
 	CTagsNamespace
 	CTagsClass
-	CTagsStructure
-	CTagsEnumeratorName
-	CTagsUnion
-	CTagsType
-	CTagsEnumerationValue
 	CTagsDefinedName
-	CTagsConstant
+	CTagsType
 	CTagsMethod
-	CTagsMember
-	CTagsProperty
 	CTagsFunction
+	CTagsEnumerationValue
+	CTagsEnumeratorName
+	CTagsConstant
 	CTagsGlobalVariable
+	CTagsUnion
+	CTagsProperty
+	CTagsMember
+	CTagsStructure
 SkipList:
 IsKeyword:@,48-57,_,192-255
 

--- a/plugin/TagHighlight/data/languages/c++.txt
+++ b/plugin/TagHighlight/data/languages/c++.txt
@@ -18,5 +18,20 @@ ReservedKeywords:
 	static static_assert static_cast struct switch synchronized template this
 	thread_local throw true try typedef typeid typename union unsigned using
 	virtual void volatile wchar_t while xor xor_eq
+Priority:
+	CTagsNamespace
+	CTagsClass
+	CTagsStructure
+	CTagsEnumeratorName
+	CTagsUnion
+	CTagsType
+	CTagsEnumerationValue
+	CTagsDefinedName
+	CTagsConstant
+	CTagsMethod
+	CTagsMember
+	CTagsProperty
+	CTagsFunction
+	CTagsGlobalVariable
 
 # vim: ff=unix:noet

--- a/plugin/TagHighlight/data/languages/c++.txt
+++ b/plugin/TagHighlight/data/languages/c++.txt
@@ -1,0 +1,22 @@
+FriendlyName:c++
+CTagsName:c++
+PythonExtensionMatcher:(cc|hh|cpp|hpp|cxx|hxx)
+VimExtensionMatcher:\(cc\|hh\|cpp\|hpp\|cxx\|hxx\)
+VimSyntaxes:cpp
+VimFileTypes:cpp
+Suffix:c++
+SpecialSyntaxHandlers:TagHighlight#SpecialHandlers#CRainbowHandler
+# Taken from http://en.cppreference.com/w/cpp/keyword
+ReservedKeywords:
+	alignas alignof and and_eq asm atomic_cancel atomic_commit atomic_noexcept auto
+	bitand bitor bool break case catch char char8_t char16_t char32_t class compl
+	concept const consteval constexpr constinit const_cast continue co_await
+	co_return co_yield decltype default delete do double dynamic_cast else enum
+	explicit export extern false float for friend goto if inline int long mutable
+	namespace new noexcept not not_eq nullptr operator or or_eq private protected
+	public reflexpr register reinterpret_cast requires return short signed sizeof
+	static static_assert static_cast struct switch synchronized template this
+	thread_local throw true try typedef typeid typename union unsigned using
+	virtual void volatile wchar_t while xor xor_eq
+
+# vim: ff=unix:noet

--- a/plugin/TagHighlight/data/languages/c.txt
+++ b/plugin/TagHighlight/data/languages/c.txt
@@ -1,24 +1,17 @@
 FriendlyName:c
 CTagsName:c
-PythonExtensionMatcher:(c|cc|cpp|h|hpp|cxx|hxx|hh)
-VimExtensionMatcher:\(c\|cc\|cpp\|h\|hpp\|cxx\|hxx\|hh\)
-VimSyntaxes:c,cpp
-VimFileTypes:c,cpp
+PythonExtensionMatcher:(c|h)
+VimExtensionMatcher:\(c\|h\)
+VimSyntaxes:c
+VimFileTypes:c
 Suffix:c
 SpecialSyntaxHandlers:TagHighlight#SpecialHandlers#CRainbowHandler
-# Note that these keywords are for C++ - TagHighlight does not
-# distinguish between C and C++ so uses the (longer) C++ list here.
-# Taken from http://en.cppreference.com/w/cpp/keyword
+# Taken from http://en.cppreference.com/w/c/keyword
 ReservedKeywords:
-	alignas alignof and and_eq asm auto bitand bitor bool break
-	case catch char char16_t char32_t class compl const constexpr
-	const_cast continue decltype default delete do double dynamic_cast
-	else enum explicit export extern false float for friend goto if
-	inline int long mutable namespace new noexcept not not_eq nullptr
-	operator or or_eq private protected public register reinterpret_cast
-	return short signed sizeof static static_assert static_cast
-	struct switch template this thread_local throw true try typedef
-	typeid typename union unsigned using virtual void volatile wchar_t
-	while xor xor_eq
+	auto break case char const continue default do double else enum extern
+	float for goto if inline int long register restrict return short signed
+	sizeof static struct switch typedef union unsigned void volatile while
+	_Alignas _Alignof _Atomic _Bool _Complex _Generic _Imaginary _Noreturn
+	_Static_assert _Thread_local
 
 # vim: ff=unix:noet


### PR DESCRIPTION
I've extracted *LanguageHandler* for C++ from the existing *LanguageHandler* for C so TagHighlight can create `types_c++.tghl` **and** `types_c.tghl`.

This allows for better interoperability with my [`vim-cpptags.py`](https://github.com/zdzislaw-s/vim-cpptags) python script.